### PR TITLE
Fixed getPosition() to use getPosition() instead of getVelocity()

### DIFF
--- a/src/main/java/frc/slicelibs/TalonFXPositionalSubsytem.java
+++ b/src/main/java/frc/slicelibs/TalonFXPositionalSubsytem.java
@@ -89,7 +89,7 @@ public class TalonFXPositionalSubsytem extends SubsystemBase {
     public double[] getPosition() {
         double[] position = new double[motors.length];
         for (int i = 0; i < motors.length; i++) {
-            position[i] = motors[i].getVelocity().getValueAsDouble();
+            position[i] = motors[i].getPosition().getValueAsDouble();
         }
         return position;
     }


### PR DESCRIPTION
Fix for TalonFXPositionalSubsytem's getPosition() method grabbing velocity instead of position.